### PR TITLE
Mirror xends so the nut traps are on top

### DIFF
--- a/box_frame/x-end.scad
+++ b/box_frame/x-end.scad
@@ -116,8 +116,8 @@ module x_tensioner(len=62, idler_height=16) {
 
 
 translate([-40, 0, 4 - bushing_xy[0]]) x_tensioner();
-mirror([0, 0, 0]) x_end_idler(thru=true);
-translate([50, 0, 0]) x_end_motor();
+mirror([1, 0, 0]) x_end_idler(thru=true);
+mirror([1, 0, 0]) translate([-50, 0, 0]) x_end_motor();
 
 module pushfit_rod(diameter, length){
     cylinder(h = length, r=diameter/2, $fn=30);


### PR DESCRIPTION
Makess less problems when M5 nut is not aligned with steppers
