### PR TITLE
Revised Config Comments

### DIFF
--- a/old_single_plate/configuration.scad-dist
+++ b/old_single_plate/configuration.scad-dist
@@ -18,11 +18,6 @@ belt_tooth_ratio = 0.5;
 //belt_tooth_distance = 2.032;
 //belt_tooth_ratio = 0.64;
 
-// GT2 - There are a bunch of GT2 belts with different tooth-to-tooth distance
-// adjust to your needs
-// belt_tooth_distance = 2;
-// belt_tooth_ratio = 0.5;
-
 // Select your hot-end mount ******************************************************
 
 // 0 = none; 1 = groove-mount (J-head/MakerGear etc.)


### PR DESCRIPTION
Removed the GT2 belt settings that I added to old_single_plate config on my last commit. They won't print because this part prints flat.
