### PR TITLE
Fix grinding of big wheel axle/hobbled bolt

### DIFF
--- a/box_frame/extras/gregs-wade-v3.scad
+++ b/box_frame/extras/gregs-wade-v3.scad
@@ -411,6 +411,8 @@ echo("bhmh", mounting_holes)
 			translate([0,0,-1])
 			b608(h=9);
 		
+			translate([0,0,8]) cylinder(r=13/2,h=1); // hlavac@code.cz: make the above bearing free to rotate
+		
 			translate([0,0,20])
 			b608(h=9);
 		


### PR DESCRIPTION
Fixed hub clearance for 608 bearing on the big extruder wheel axle/hobbled bolt in extras/gregs-wade-v3.scad to stop the bearing hub from grinding the wall and make the axle free to rotate.
