### PR TITLE
simple makefile change to allow for easy output of AMF or STL

### DIFF
--- a/box_frame/Makefile
+++ b/box_frame/Makefile
@@ -1,22 +1,24 @@
 #openscad -o output/bushing.stl bushing.scad
 
+# Type of 3D Model file to output. Known to work with AMF or STL.
+OUTPUT_TYPE=stl
 INCLUDES = $(wildcard inc/*.scad)
 
 MODELS = $(filter-out configuration.scad, $(wildcard *.scad))
 
 STL_FILES_1 = $(foreach src, $(MODELS),output/$(src))
-STL_FILES = $(STL_FILES_1:%.scad=%.stl)
+STL_FILES = $(STL_FILES_1:%.scad=%.$(OUTPUT_TYPE))
 
 all: $(STL_FILES)
 
 MODELS_EXTRAS = $(wildcard extras/*.scad)
 STL_EXTRAS_1 = $(foreach src, $(MODELS_EXTRAS),output/$(src))
-STL_EXTRAS = $(STL_EXTRAS_1:%.scad=%.stl)
+STL_EXTRAS = $(STL_EXTRAS_1:%.scad=%.$(OUTPUT_TYPE))
 
 extras: $(STL_EXTRAS)
 
-output/%.stl: %.scad $(INCLUDES) configuration.scad
+output/%.$(OUTPUT_TYPE): %.scad $(INCLUDES) configuration.scad
 	openscad -o $@ $<
 
 clean:
-	rm output/*.stl output/*.gcode output/extras/*.stl output/extras/*.gcode
+	rm output/*.$(OUTPUT_TYPE) output/*.gcode output/extras/*.stl output/extras/*.gcode


### PR DESCRIPTION
The default is STL, but can change extension in makefile to amf (in just one place) to get AMF output, which OpenSCAD supports.
Changing the file extension to other things OpenSCAD supports will, naturally, export to those formats.
